### PR TITLE
Kria KV260 board

### DIFF
--- a/boards/AMD-Xilinx/Kria-KV260.md
+++ b/boards/AMD-Xilinx/Kria-KV260.md
@@ -3,18 +3,19 @@
 Product page: https://www.xilinx.com/products/som/kria/kv260-vision-starter-kit.html
 
 Arm IP:
-- [Cortex-A53](/ip/cortex-a.md)
-- [Cortex-R5F](/ip/cortex-r.md)
-- [Mali-400](/ip/mali.md)
+- [Cortex-A53](/ip/cortex-a.md) (x4)
+- [Cortex-R5F](/ip/cortex-r.md) (x2)
+- [Mali-400](/ip/mali.md) (x1)
 - [AMBA AXI4 Interconnect](/board-of-boards/ip/)
+
+
 Use Cases:
 - [AI/ML](/use-cases/ai-ml.md#embedded)
-- [IoT](/use-cases/iot.md)
 - [Real-time Industrial Control](/use-cases/)
 
 ## Specifications
 Board User Guide: [KV260 User Guide](https://docs.xilinx.com/r/en-US/ug1089-kv260-starter-kit)
-Zynq Datasheet: [Zynq©  UltraScale+™ MPSoC DataSheet: Overview (DS891](https://docs.xilinx.com/v/u/en-US/ds891-zynq-ultrascale-plus-overview))
+
 - Quad-core Cortex-A53 @ 1.5 GHz
 - Dual-core Cortex-R5F @ 600 MHz
 - Mali-400 @ 667 MHz

--- a/boards/AMD-Xilinx/Kria-KV260.md
+++ b/boards/AMD-Xilinx/Kria-KV260.md
@@ -1,0 +1,33 @@
+# AMD-Xilinx Kria KV260 SoC Board
+
+Product page: https://www.xilinx.com/products/som/kria/kv260-vision-starter-kit.html
+
+Arm IP:
+- [Cortex-A53](/ip/cortex-a.md)
+- [Cortex-R5F](/ip/cortex-r.md)
+- [Mali-400](/ip/mali.md)
+- [AMBA AXI4 Interconnect](/board-of-boards/ip/)
+Use Cases:
+- [AI/ML](/use-cases/ai-ml.md#embedded)
+- [IoT](/use-cases/iot.md)
+- [Real-time Industrial Control](/use-cases/)
+
+## Specifications
+Board User Guide: [KV260 User Guide](https://docs.xilinx.com/r/en-US/ug1089-kv260-starter-kit)
+Zynq Datasheet: [Zynq©  UltraScale+™ MPSoC DataSheet: Overview (DS891](https://docs.xilinx.com/v/u/en-US/ds891-zynq-ultrascale-plus-overview))
+- Quad-core Cortex-A53 @ 1.5 GHz
+- Dual-core Cortex-R5F @ 600 MHz
+- Mali-400 @ 667 MHz
+- 4 GB DDR4 memory
+
+### Dedicated I/Os and Peripherals
+- DisplayPort Controller (x1)
+- HDMI Controller (x1)
+- RJ45 Ethernet (x1)
+- USB 3.0 (x4)
+- 12-pin PMOD Connector (x1)
+- MicroSD (x1)
+- Raspberry Pi Camera Connector (x1)
+- JTAG Interface (x1)
+- Micro-USB UART/JTAG (x1)
+- IAS Connectors (x2)

--- a/boards/AMD-Xilinx/Kria-KV260.md
+++ b/boards/AMD-Xilinx/Kria-KV260.md
@@ -6,12 +6,13 @@ Arm IP:
 - [Cortex-A53](/ip/cortex-a.md) (x4)
 - [Cortex-R5F](/ip/cortex-r.md) (x2)
 - [Mali-400](/ip/mali.md) (x1)
-- [AMBA AXI4 Interconnect](/board-of-boards/ip/)
+- [AMBA AXI4 Interconnect](/ip/amba-axi.md)
 
 
 Use Cases:
-- [AI/ML](/use-cases/ai-ml.md#embedded)
-- [Real-time Industrial Control](/use-cases/)
+- [AI/ML](/use-cases/ai-ml.md)
+- [Industrial/Real-time](/use-cases/industrial-rt.md)
+- [Robotics](/use-cases/robotics.md)
 
 ## Specifications
 Board User Guide: [KV260 User Guide](https://docs.xilinx.com/r/en-US/ug1089-kv260-starter-kit)

--- a/ip/amba-axi.md
+++ b/ip/amba-axi.md
@@ -1,0 +1,6 @@
+# AMBA-AXI Interconnect IP
+
+These devices include the AXI interconnects.
+
+## AXI4
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)

--- a/ip/axi4.md
+++ b/ip/axi4.md
@@ -1,3 +1,0 @@
-# AXI4 Interconnect
-
-These devices include the AXI4 interconnects.

--- a/ip/axi4.md
+++ b/ip/axi4.md
@@ -1,0 +1,3 @@
+# AXI4 Interconnect
+
+These devices include the AXI4 interconnects.

--- a/ip/cortex-a.md
+++ b/ip/cortex-a.md
@@ -5,3 +5,5 @@ These devices include one or more Arm Cortex-A cores.
 ## Coretex-A53
 
 - [RaspberryPi 3](/boards/Raspberry-Pi-Foundation/raspberrypi3.md)
+
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)

--- a/ip/cortex-r.md
+++ b/ip/cortex-r.md
@@ -1,0 +1,7 @@
+# Cortex-R
+
+These devices include one or more Cortex-R family of processors.
+
+## Cortex R5F 
+
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)

--- a/ip/mali.md
+++ b/ip/mali.md
@@ -1,3 +1,6 @@
 # Mali
 
 These devices include Arm Mali graphics cores.
+
+## Mali-400
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)

--- a/use-cases/industrial-rt.md
+++ b/use-cases/industrial-rt.md
@@ -1,0 +1,5 @@
+## Industrial/Real-time
+
+These boards are suitable for industrial/real-time control solutions.
+
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)

--- a/use-cases/robotics.md
+++ b/use-cases/robotics.md
@@ -1,3 +1,5 @@
 ## Robotics
 
 The following boards are suitable for robotics and automation.
+
+- [AMD-Xilinx Kria KV260](/boards/AMD-Xilinx/Kria-KV260.md)


### PR DESCRIPTION
This pull request is for adding the AMD-Xilinx Kria KV260 SoC board. This PR has the following updates. 
1. Board file for Kria KV260
2. IP file for AXI4 Interconnect